### PR TITLE
adding AppBridgeService

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,6 +6,7 @@ import { Routes, RouterModule } from '@angular/router';
 import { NovoElementsModule } from 'novo-elements';
 // APP
 import { AppComponent } from './app.component';
+import { AppBridgeService } from './service/app-bridge.service';
 
 const routes: Routes = [
   { path: '', redirectTo: 'sample', pathMatch: 'full' },
@@ -27,6 +28,7 @@ const routes: Routes = [
     // APP
   ],
   providers: [
+    AppBridgeService
     // Vendor Overrides
     // APP
   ],

--- a/src/app/sample/sample.module.ts
+++ b/src/app/sample/sample.module.ts
@@ -14,14 +14,6 @@ export const routes: Routes = [
   { path: '', component: SampleComponent, pathMatch: 'full' }
 ];
 
-const bridge = new AppBridge('SampleExtension');
-bridge.tracing = true;
-bridge.register(environment.appBridgeConfig.sample);
-
-export function setupAppBridge() {
-  return bridge;
-}
-
 @NgModule({
   imports: [
     // NG2
@@ -38,7 +30,6 @@ export function setupAppBridge() {
   ],
   providers: [
     // Vendor Overrides
-    { provide: AppBridge, useFactory: setupAppBridge }
     // APP
   ]
 })

--- a/src/app/service/app-bridge.service.ts
+++ b/src/app/service/app-bridge.service.ts
@@ -1,0 +1,44 @@
+import {Injectable} from '@angular/core';
+
+import {AppBridge} from 'novo-elements';
+
+import { environment } from '../../environments/environment';
+
+@Injectable()
+export class AppBridgeService {
+
+  private bridge: AppBridge;
+
+  private registered: boolean = false;
+
+  constructor() {
+    this.bridge = new AppBridge(environment.appBridgeConfig.title);
+    this.bridge.tracing = true;
+    this.register();
+  }
+
+  execute(execute: (bridge: AppBridge) => void) {
+    if (this.registered) {
+      execute(this.bridge);
+    } else {
+      const interval = setInterval(() => {
+        if (this.registered) {
+          clearInterval(interval);
+
+          execute(this.bridge);
+        }
+      }, 500);
+    }
+  }
+
+  private register() {
+    this.bridge.register(environment.appBridgeConfig).then( () => {
+      this.registered = true;
+    }, () => {
+      setTimeout(() => {
+        this.register();
+      }, 500);
+    });
+  }
+
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,10 +1,8 @@
 export const environment = {
   production: true,
   appBridgeConfig: {
-    sample: {
-      title: 'Sample',
-      url: 'https://HOSTED_URL/sample',
-      color: 'blue'
-    }
+    title: 'CustomApp',
+    url: 'https://HOSTED_URL/sample',
+    color: 'blue'
   }
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,10 +6,8 @@
 export const environment = {
   production: false,
   appBridgeConfig: {
-    sample: {
-      title: 'Sample',
-      url: 'https://localhost:4200/sample',
-      color: 'blue'
-    }
+    title: 'CustomApp',
+    url: 'http://localhost:4200/sample',
+    color: 'blue'
   }
 };

--- a/tslint.json
+++ b/tslint.json
@@ -50,10 +50,6 @@
     "no-empty": false,
     "no-empty-interface": true,
     "no-eval": true,
-    "no-inferrable-types": [
-      true,
-      "ignore-params"
-    ],
     "no-misused-new": true,
     "no-non-null-assertion": true,
     "no-shadowed-variable": true,


### PR DESCRIPTION
Adding service class that helps to use AppBridge in locations where there may be a race condition between BH loading AppBridge and the extension-starter using AppBridge (custom tabs definitely do this, but I believe menu actions may as well)

I also modified the config files to only have 1 AppBridge config...this could arguably go the other way but the way we've been using the extension-starter, even if there are separate modules they all end up using the same AppBridge config (as the only really identifying piece is the name)

Finally I removed one TSLint option that didn't make much sense to me (basically kept you from using boolean literal types).  I can add this in if there's a good reason for it